### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/davehorner/jetkvm_control/compare/v0.1.1...v0.1.2) - 2025-03-03
+
+### Added
+
+- update dependencies, logging, and documentation
+
 ## [0.1.1](https://github.com/davehorner/jetkvm_control/compare/v0.1.0...v0.1.1) - 2025-03-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,7 +1345,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jetkvm_control"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A control client for JetKVM over WebRTC."
 license = "MIT"
 repository = "https://github.com/davehorner/jetkvm_control"
 homepage = "https://github.com/davehorner/jetkvm_control"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["David Horner"]
 


### PR DESCRIPTION



## 🤖 New release

* `jetkvm_control`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/davehorner/jetkvm_control/compare/v0.1.1...v0.1.2) - 2025-03-03

### Added

- update dependencies, logging, and documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).