### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/davehorner/jetkvm_control/compare/v0.1.3...v0.1.4) - 2025-03-04
+
+### Added
+
+- *(keyboard)* add send_key_combinations API and Lua binding
+
 ## [0.1.3](https://github.com/davehorner/jetkvm_control/compare/v0.1.2...v0.1.3) - 2025-03-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jetkvm_control"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A control client for JetKVM over WebRTC."
 license = "MIT"
 repository = "https://github.com/davehorner/jetkvm_control"
 homepage = "https://github.com/davehorner/jetkvm_control"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["David Horner"]
 


### PR DESCRIPTION



## 🤖 New release

* `jetkvm_control`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/davehorner/jetkvm_control/compare/v0.1.3...v0.1.4) - 2025-03-04

### Added

- *(keyboard)* add send_key_combinations API and Lua binding
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).