### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/davehorner/jetkvm_control/compare/jetkvm_control-v0.1.3...jetkvm_control-v0.2.0) - 2025-03-09
+
+### Added
+
+- initial release of jetkvm_control_svr with TLS and HMAC authentication
+- *(keyboard)* add send_key_combinations API and Lua binding
+
 ## [0.1.3](https://github.com/davehorner/jetkvm_control/compare/v0.1.2...v0.1.3) - 2025-03-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jetkvm_control"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "A control client for JetKVM over WebRTC."
 license = "MIT"
 repository = "https://github.com/davehorner/jetkvm_control"
 homepage = "https://github.com/davehorner/jetkvm_control"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 authors = ["David Horner"]
 

--- a/jetkvm_control_platform/CHANGELOG.md
+++ b/jetkvm_control_platform/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/davehorner/jetkvm_control/releases/tag/jetkvm_control_platform-v0.1.0) - 2025-03-09
+
+### Added
+
+- initial release of jetkvm_control_svr with TLS and HMAC authentication

--- a/jetkvm_control_svr/CHANGELOG.md
+++ b/jetkvm_control_svr/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.3](https://github.com/davehorner/jetkvm_control/releases/tag/jetkvm_control_svr-v0.1.3) - 2025-03-09
+
+### Added
+
+- initial release of jetkvm_control_svr with TLS and HMAC authentication


### PR DESCRIPTION



## 🤖 New release

* `jetkvm_control`: 0.1.3 -> 0.2.0 (⚠ API breaking changes)
* `jetkvm_control_platform`: 0.1.0
* `jetkvm_control_svr`: 0.1.3

### ⚠ `jetkvm_control` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field JetKvmConfig.ca_cert_path in /tmp/.tmpqRdqQy/jetkvm_control/src/jetkvm_config.rs:19
  field JetKvmConfig.no_auto_logout in /tmp/.tmpqRdqQy/jetkvm_control/src/jetkvm_config.rs:21
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `jetkvm_control`

<blockquote>

## [0.2.0](https://github.com/davehorner/jetkvm_control/compare/jetkvm_control-v0.1.3...jetkvm_control-v0.2.0) - 2025-03-09

### Added

- initial release of jetkvm_control_svr with TLS and HMAC authentication
- *(keyboard)* add send_key_combinations API and Lua binding
</blockquote>

## `jetkvm_control_platform`

<blockquote>

## [0.1.0](https://github.com/davehorner/jetkvm_control/releases/tag/jetkvm_control_platform-v0.1.0) - 2025-03-09

### Added

- initial release of jetkvm_control_svr with TLS and HMAC authentication
</blockquote>

## `jetkvm_control_svr`

<blockquote>

## [0.1.3](https://github.com/davehorner/jetkvm_control/releases/tag/jetkvm_control_svr-v0.1.3) - 2025-03-09

### Added

- initial release of jetkvm_control_svr with TLS and HMAC authentication
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).