### PR TITLE
feat: add send_rpc Lua binding, ATX power control, config flag, and logging improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,6 +1503,7 @@ dependencies = [
  "hmac",
  "lazy_static",
  "mlua",
+ "openssl",
  "rand 0.9.0",
  "rcgen",
  "regex",
@@ -1919,6 +1920,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +1936,7 @@ checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1513,6 +1513,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "tempfile",
  "tokio",
  "tokio-rustls",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ hmac = { version = "0.12.1", optional = true }
 rustls = { version = "0.23.23", optional = true }
 rcgen = { version = "0.13.2", optional = true }
 sha2 = { version = "0.10.8", optional = true }
-
+openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]
 regex = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,4 @@ openssl = { version = "0.10", features = ["vendored"] }
 
 [dev-dependencies]
 regex = "1.11.1"
+tempfile = "3"

--- a/lua-examples/atx_power_long.lua
+++ b/lua-examples/atx_power_long.lua
@@ -1,0 +1,12 @@
+-- atx_power_long.lua
+-- Sends a long ATX power button press (~5 seconds) to force-off the machine.
+-- This is equivalent to holding the physical power button — it bypasses the OS
+-- and cuts power unconditionally. Use with caution: unsaved work will be lost
+-- and filesystems may not be cleanly unmounted.
+--
+-- Usage:
+--   jetkvm_control atx_power_long.lua
+
+print("Sending ATX long power press (force off)...")
+local result = send_rpc("setATXPowerAction", '{"action": "power-long"}')
+print("ATX power-long result: " .. result)

--- a/lua-examples/atx_power_short.lua
+++ b/lua-examples/atx_power_short.lua
@@ -1,0 +1,12 @@
+-- atx_power_short.lua
+-- Sends a short ATX power button press (~200ms) to the machine connected via
+-- the JetKVM ATX Power Control extension module. This is the normal power
+-- toggle: turns the machine on if off, or triggers a graceful shutdown if the
+-- OS is configured to handle ACPI power button events.
+--
+-- Usage:
+--   jetkvm_control atx_power_short.lua
+
+print("Sending ATX short power press...")
+local result = send_rpc("setATXPowerAction", '{"action": "power-short"}')
+print("ATX power-short result: " .. result)

--- a/lua-examples/atx_reset.lua
+++ b/lua-examples/atx_reset.lua
@@ -1,0 +1,16 @@
+-- atx_reset.lua
+-- Sends an ATX reset signal to the machine connected via the JetKVM ATX Power
+-- Control extension module. This is equivalent to pressing the physical reset
+-- button on the motherboard (momentary ~200ms pulse).
+--
+-- Prerequisites:
+--   - JetKVM device with ATX Power Control extension module installed
+--   - jetkvm_control configured with host/password (jetkvm_control.toml or CLI flags)
+--
+-- Usage:
+--   jetkvm_control atx_reset.lua
+--   jetkvm_control -H 10.0.0.132 -P yourpassword atx_reset.lua
+
+print("Sending ATX reset...")
+local result = send_rpc("setATXPowerAction", '{"action": "reset"}')
+print("ATX reset result: " .. result)

--- a/lua-examples/atx_reset.lua
+++ b/lua-examples/atx_reset.lua
@@ -9,7 +9,7 @@
 --
 -- Usage:
 --   jetkvm_control atx_reset.lua
---   jetkvm_control -H 10.0.0.132 -P yourpassword atx_reset.lua
+--   jetkvm_control -H 192.168.0.100 -P yourpassword atx_reset.lua
 
 print("Sending ATX reset...")
 local result = send_rpc("setATXPowerAction", '{"action": "reset"}')

--- a/lua-examples/atx_status.lua
+++ b/lua-examples/atx_status.lua
@@ -1,11 +1,29 @@
 -- atx_status.lua
 -- Queries the current ATX LED state from the JetKVM ATX Power Control extension.
--- Returns a JSON object with "power" (bool) and "hdd" (bool) fields indicating
--- whether the power LED and HDD activity LED are currently lit.
+-- Returns "power" (bool) and "hdd" (bool) indicating whether the power LED and
+-- HDD activity LED are currently lit.
+--
+-- NOTE: The JetKVM reads the power LED state from the motherboard header pin.
+-- Some motherboards supply standby voltage (5Vsb) to the power LED header even
+-- when the system is in S5/soft-off state. This can cause "power: true" to be
+-- reported even though the machine appears off. This is a hardware behavior,
+-- not a bug in this script.
 --
 -- Usage:
 --   jetkvm_control atx_status.lua
 
 print("Querying ATX state...")
-local result = send_rpc("getATXState", '{}')
-print("ATX state: " .. result)
+local result_json = send_rpc("getATXState", '{}')
+
+-- Parse the JSON-RPC response to extract the actual result.
+-- The raw response looks like: {"id":1,"jsonrpc":"2.0","result":{"hdd":false,"power":true}}
+-- We extract the "result" object to display just the power and hdd states.
+local power = result_json:match('"power"%s*:%s*(true)')
+local hdd   = result_json:match('"hdd"%s*:%s*(true)')
+
+local power_state = power and "ON" or "OFF"
+local hdd_state   = hdd   and "ACTIVE" or "INACTIVE"
+
+print(string.format("Power LED: %s", power_state))
+print(string.format("HDD LED:   %s", hdd_state))
+print("(raw: " .. result_json .. ")")

--- a/lua-examples/atx_status.lua
+++ b/lua-examples/atx_status.lua
@@ -1,0 +1,11 @@
+-- atx_status.lua
+-- Queries the current ATX LED state from the JetKVM ATX Power Control extension.
+-- Returns a JSON object with "power" (bool) and "hdd" (bool) fields indicating
+-- whether the power LED and HDD activity LED are currently lit.
+--
+-- Usage:
+--   jetkvm_control atx_status.lua
+
+print("Querying ATX state...")
+local result = send_rpc("getATXState", '{}')
+print("ATX state: " .. result)

--- a/src/jetkvm_config.rs
+++ b/src/jetkvm_config.rs
@@ -330,3 +330,129 @@ pub async fn interactive_config_location() -> Result<()> {
 
     Ok(())
 }
+
+/// Unit tests for JetKvmConfig serialization, deserialization, and file I/O.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Helper: creates a temporary TOML config file with the given content.
+    /// Returns a (path_string, _guard) tuple — the guard keeps the file alive
+    /// until it goes out of scope in the calling test.
+    fn write_temp_config(content: &str) -> (String, tempfile::NamedTempFile) {
+        let mut tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        tmp.write_all(content.as_bytes()).expect("write temp file");
+        let path = tmp.path().to_string_lossy().into_owned();
+        (path, tmp)
+    }
+
+    /// Verify that Default produces the expected zero-value config.
+    #[test]
+    fn test_default_config_values() {
+        let cfg = JetKvmConfig::default();
+        assert_eq!(cfg.host, "");
+        assert_eq!(cfg.port, "80");
+        assert_eq!(cfg.api, "/webrtc/session");
+        assert_eq!(cfg.password, "");
+        assert_eq!(cfg.ca_cert_path, "cert.pem");
+        assert!(!cfg.no_auto_logout);
+    }
+
+    /// Verify session_url() builds the correct HTTP URL from config fields.
+    #[test]
+    fn test_session_url() {
+        let cfg = JetKvmConfig {
+            host: "10.0.0.1".into(),
+            port: "8080".into(),
+            api: "/webrtc/session".into(),
+            ..Default::default()
+        };
+        assert_eq!(cfg.session_url(), "http://10.0.0.1:8080/webrtc/session");
+    }
+
+    /// Verify save → load roundtrip preserves all fields exactly.
+    #[test]
+    fn test_save_and_load_roundtrip() {
+        let cfg = JetKvmConfig {
+            host: "192.168.1.100".into(),
+            port: "443".into(),
+            api: "/api/v2".into(),
+            password: "s3cret".into(),
+            ca_cert_path: "/etc/ssl/cert.pem".into(),
+            no_auto_logout: true,
+        };
+
+        let tmp = tempfile::NamedTempFile::new().expect("create temp file");
+        let path = tmp.path().to_string_lossy().into_owned();
+
+        cfg.save_to_file(&path).expect("save should succeed");
+        let loaded = JetKvmConfig::load_from_file(&path).expect("load should succeed");
+
+        assert_eq!(loaded.host, "192.168.1.100");
+        assert_eq!(loaded.port, "443");
+        assert_eq!(loaded.api, "/api/v2");
+        assert_eq!(loaded.password, "s3cret");
+        assert_eq!(loaded.ca_cert_path, "/etc/ssl/cert.pem");
+        assert!(loaded.no_auto_logout);
+    }
+
+    /// Simulates the --config flag: loading from an arbitrary explicit path.
+    #[test]
+    fn test_load_from_file_explicit_path() {
+        let content = r#"
+host = "192.168.0.100"
+port = "80"
+api = "/webrtc/session"
+password = "testpass"
+"#;
+        let (path, _guard) = write_temp_config(content);
+        let cfg = JetKvmConfig::load_from_file(&path).expect("should load from explicit path");
+
+        assert_eq!(cfg.host, "192.168.0.100");
+        assert_eq!(cfg.port, "80");
+        assert_eq!(cfg.password, "testpass");
+        // ca_cert_path should fall back to the serde default since it's absent from the file.
+        assert_eq!(cfg.ca_cert_path, "cert.pem");
+    }
+
+    /// Loading from a nonexistent path must return an error, not panic.
+    #[test]
+    fn test_load_from_file_missing_path() {
+        let result = JetKvmConfig::load_from_file("/nonexistent/path/config.toml");
+        assert!(result.is_err(), "loading from a missing file should error");
+    }
+
+    /// Malformed TOML must produce a parse error.
+    #[test]
+    fn test_load_from_file_invalid_toml() {
+        let (path, _guard) = write_temp_config("this is not valid toml {{{{");
+        let result = JetKvmConfig::load_from_file(&path);
+        assert!(result.is_err(), "invalid TOML should produce a parse error");
+    }
+
+    /// A TOML file missing required fields (port, api, password) must fail to deserialize.
+    #[test]
+    fn test_load_from_file_missing_required_fields() {
+        let (path, _guard) = write_temp_config(r#"host = "10.0.0.1""#);
+        let result = JetKvmConfig::load_from_file(&path);
+        assert!(result.is_err(), "missing required fields should error");
+    }
+
+    /// Optional fields (ca_cert_path, no_auto_logout) should take their serde defaults
+    /// when omitted from the TOML file.
+    #[test]
+    fn test_load_from_file_optional_fields_default() {
+        let content = r#"
+host = "10.0.0.1"
+port = "80"
+api = "/webrtc/session"
+password = "pass"
+"#;
+        let (path, _guard) = write_temp_config(content);
+        let cfg = JetKvmConfig::load_from_file(&path).expect("should load");
+
+        assert_eq!(cfg.ca_cert_path, "cert.pem", "ca_cert_path should default to cert.pem");
+        assert!(!cfg.no_auto_logout, "no_auto_logout should default to false");
+    }
+}

--- a/src/jetkvm_rpc_client.rs
+++ b/src/jetkvm_rpc_client.rs
@@ -89,8 +89,44 @@ impl JetKvmRpcClient {
         peer_connection.set_local_description(offer.clone()).await?;
         debug!("Local SDP Offer set.");
 
+        // 5b. Wait for ICE candidate gathering to complete before sending the offer.
+        //
+        // After setting the local description, the WebRTC stack begins asynchronously
+        // discovering local network candidates (host, srflx, relay) via mDNS/STUN/TURN.
+        // The original code sent the offer immediately — before any candidates were
+        // gathered — which resulted in an SDP with zero ICE candidates. The remote peer
+        // (JetKVM device) would reply with its own candidates, but the local ICE agent
+        // had no local candidates to form pairs with, causing the connection to stall
+        // indefinitely at "pingAllCandidates called with no candidate pairs."
+        //
+        // Fix: use a oneshot channel to block until the ICE gatherer signals Complete,
+        // with a 10-second timeout as a safety net. After this, re-read the local
+        // description — it now contains the gathered `a=candidate` lines.
+        let (gather_tx, gather_rx) = tokio::sync::oneshot::channel::<()>();
+        let gather_tx = std::sync::Mutex::new(Some(gather_tx));
+        peer_connection.on_ice_gathering_state_change(Box::new(move |state| {
+            debug!("ICE gathering state changed: {:?}", state);
+            if state == webrtc::ice_transport::ice_gatherer_state::RTCIceGathererState::Complete {
+                // Signal that gathering is done; .take() ensures we only fire once.
+                if let Some(tx) = gather_tx.lock().unwrap().take() {
+                    let _ = tx.send(());
+                }
+            }
+            Box::pin(async {})
+        }));
+        // Block until gathering finishes or 10s elapses (whichever comes first).
+        let _ = tokio::time::timeout(Duration::from_secs(10), gather_rx).await;
+        debug!("ICE gathering complete (or timed out).");
+
+        // Re-read the local description — it now includes the gathered ICE candidates,
+        // unlike the original `offer` which was captured before gathering started.
+        let local_desc = peer_connection
+            .local_description()
+            .await
+            .ok_or_else(|| anyhow!("No local description after ICE gathering"))?;
+
         // 6. Wrap the offer in JSON.
-        let offer_type_str = match offer.sdp_type {
+        let offer_type_str = match local_desc.sdp_type {
             RTCSdpType::Offer => "offer",
             RTCSdpType::Answer => "answer",
             RTCSdpType::Pranswer => "pranswer",
@@ -106,7 +142,7 @@ impl JetKvmRpcClient {
         }
 
         let local_offer_json = LocalOfferJson {
-            sdp: offer.sdp.clone(),
+            sdp: local_desc.sdp.clone(),
             sdp_type: offer_type_str.to_owned(),
         };
 

--- a/src/lua_engine.rs
+++ b/src/lua_engine.rs
@@ -43,11 +43,68 @@ impl LuaEngine {
     }
 
     /// Registers built-in functions from other modules (e.g., keyboard and mouse) to the Lua context.
+    ///
+    /// This includes the generic `send_rpc` function which allows Lua scripts to invoke
+    /// arbitrary JSON-RPC methods on the JetKVM device — enabling features like ATX power
+    /// control that don't have dedicated Lua bindings.
     pub fn register_builtin_functions(&self) -> LuaResult<()> {
         keyboard::register_lua(&self.lua, self.client.clone())?;
         mouse::register_lua(&self.lua, self.client.clone())?;
         jetkvm_control_svr_client::register_lua(&self.lua)?;
         Self::register_delay(&self.lua)?;
+        Self::register_send_rpc(&self.lua, self.client.clone())?;
+        Ok(())
+    }
+
+    /// Registers a generic `send_rpc(method, params_json)` Lua function that forwards
+    /// arbitrary JSON-RPC calls to the JetKVM device over the WebRTC data channel.
+    ///
+    /// This bridges the gap between the JetKVM firmware's full JSON-RPC API and the
+    /// subset of Lua bindings provided by jetkvm_control. Lua scripts can call any
+    /// method the device supports without needing a dedicated Rust binding.
+    ///
+    /// # Lua signature
+    /// ```lua
+    /// result_json = send_rpc(method_name, params_json_string)
+    /// ```
+    ///
+    /// # Arguments (from Lua)
+    /// * `method` — The JSON-RPC method name (e.g., `"setATXPowerAction"`, `"getATXState"`)
+    /// * `params_json` — A JSON string of the method parameters (e.g., `'{"action": "reset"}'`)
+    ///
+    /// # Returns
+    /// A JSON string of the RPC response, or raises a Lua error on invalid JSON or RPC failure.
+    ///
+    /// # Example Lua usage
+    /// ```lua
+    /// -- Query ATX power/HDD LED state
+    /// local state = send_rpc("getATXState", "{}")
+    /// print("ATX state: " .. state)
+    ///
+    /// -- Press the ATX reset button
+    /// send_rpc("setATXPowerAction", '{"action": "reset"}')
+    ///
+    /// -- Short press the ATX power button
+    /// send_rpc("setATXPowerAction", '{"action": "power-short"}')
+    ///
+    /// -- Long press the ATX power button (force off, holds ~5s)
+    /// send_rpc("setATXPowerAction", '{"action": "power-long"}')
+    /// ```
+    pub fn register_send_rpc(lua: &Lua, client: Arc<Mutex<JetKvmRpcClient>>) -> LuaResult<()> {
+        let send_rpc_fn = lua.create_async_function(move |_, (method, params_json): (String, String)| {
+            let client = client.clone();
+            async move {
+                // Parse the JSON string into a serde_json::Value for the RPC layer.
+                let params: serde_json::Value = serde_json::from_str(&params_json)
+                    .map_err(|e| mlua::Error::external(e))?;
+                // Forward the call through the WebRTC JSON-RPC channel.
+                let result = client.lock().await.send_rpc(&method, params).await
+                    .map_err(|e| mlua::Error::external(e))?;
+                // Return the result as a JSON string back to Lua.
+                Ok(result.to_string())
+            }
+        })?;
+        lua.globals().set("send_rpc", send_rpc_fn)?;
         Ok(())
     }
 
@@ -63,5 +120,173 @@ impl LuaEngine {
     /// Provides access to the underlying Lua instance.
     pub fn lua(&self) -> &Lua {
         &self.lua
+    }
+}
+
+/// Tests for the LuaEngine and the `send_rpc` Lua binding.
+///
+/// These tests use an unconnected `JetKvmRpcClient` (no real WebRTC session) which is
+/// sufficient to validate that:
+///   - Lua functions are correctly registered in the global namespace
+///   - JSON parsing in `send_rpc` properly rejects malformed input
+///   - The RPC layer correctly surfaces "not connected" errors
+///   - The engine can execute Lua scripts and the `delay` function works
+///
+/// Integration tests against a live JetKVM device are not included here — use the
+/// Lua example scripts in `lua-examples/` (e.g., `atx_status.lua`) for end-to-end validation.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::jetkvm_config::JetKvmConfig;
+
+    /// Helper: creates an unconnected RPC client wrapped in Arc<Mutex> for test use.
+    /// No network calls are made — the client is in a disconnected state, which is
+    /// intentional for testing error paths and function registration.
+    fn make_test_client() -> Arc<Mutex<JetKvmRpcClient>> {
+        let config = JetKvmConfig::default();
+        Arc::new(Mutex::new(JetKvmRpcClient::new(config)))
+    }
+
+    /// Verify that LuaEngine::new() produces a working Lua VM with standard globals.
+    #[test]
+    fn test_lua_engine_creation() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        assert!(engine.lua().globals().get::<mlua::Value>("print").is_ok());
+    }
+
+    /// Verify the `delay(ms)` function registers and is callable with 0ms.
+    #[test]
+    fn test_register_delay() {
+        let lua = Lua::new();
+        LuaEngine::register_delay(&lua).expect("register_delay should succeed");
+        let delay: mlua::Function = lua.globals().get("delay").expect("delay should be registered");
+        delay.call::<()>(0u64).expect("delay(0) should succeed");
+    }
+
+    /// Exhaustive check that all expected Lua globals are present after registration.
+    /// This catches regressions where a new Rust function forgets to call `.set()`.
+    #[test]
+    fn test_register_builtin_functions() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        engine
+            .register_builtin_functions()
+            .expect("register_builtin_functions should succeed");
+
+        let globals = engine.lua().globals();
+
+        // Keyboard functions (from keyboard.rs)
+        assert!(globals.get::<mlua::Function>("send_return").is_ok(), "send_return should be registered");
+        assert!(globals.get::<mlua::Function>("send_ctrl_a").is_ok(), "send_ctrl_a should be registered");
+        assert!(globals.get::<mlua::Function>("send_ctrl_c").is_ok(), "send_ctrl_c should be registered");
+        assert!(globals.get::<mlua::Function>("send_ctrl_v").is_ok(), "send_ctrl_v should be registered");
+        assert!(globals.get::<mlua::Function>("send_ctrl_x").is_ok(), "send_ctrl_x should be registered");
+        assert!(globals.get::<mlua::Function>("send_windows_key").is_ok(), "send_windows_key should be registered");
+        assert!(globals.get::<mlua::Function>("send_text").is_ok(), "send_text should be registered");
+        assert!(globals.get::<mlua::Function>("send_key_combinations").is_ok(), "send_key_combinations should be registered");
+
+        // Mouse functions (from mouse.rs)
+        assert!(globals.get::<mlua::Function>("move_mouse").is_ok(), "move_mouse should be registered");
+        assert!(globals.get::<mlua::Function>("left_click").is_ok(), "left_click should be registered");
+        assert!(globals.get::<mlua::Function>("right_click").is_ok(), "right_click should be registered");
+        assert!(globals.get::<mlua::Function>("middle_click").is_ok(), "middle_click should be registered");
+        assert!(globals.get::<mlua::Function>("double_click").is_ok(), "double_click should be registered");
+
+        // Utility functions
+        assert!(globals.get::<mlua::Function>("delay").is_ok(), "delay should be registered");
+
+        // Generic RPC binding (from register_send_rpc — enables ATX power control etc.)
+        assert!(globals.get::<mlua::Function>("send_rpc").is_ok(), "send_rpc should be registered");
+    }
+
+    /// Verify send_rpc can be registered independently (not just via register_builtin_functions).
+    #[test]
+    fn test_register_send_rpc() {
+        let client = make_test_client();
+        let lua = Lua::new();
+        LuaEngine::register_send_rpc(&lua, client).expect("register_send_rpc should succeed");
+        assert!(
+            lua.globals().get::<mlua::Function>("send_rpc").is_ok(),
+            "send_rpc should be registered"
+        );
+    }
+
+    /// send_rpc must reject malformed JSON in the params argument before touching the RPC layer.
+    #[tokio::test]
+    async fn test_send_rpc_rejects_invalid_json() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        engine
+            .register_builtin_functions()
+            .expect("register should succeed");
+
+        let result = engine
+            .exec_script(r#"send_rpc("someMethod", "not valid json{")"#)
+            .await;
+        assert!(result.is_err(), "invalid JSON params should cause an error");
+    }
+
+    /// send_rpc with valid JSON but no WebRTC connection must surface the "not connected" error.
+    #[tokio::test]
+    async fn test_send_rpc_rejects_unconnected_client() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        engine
+            .register_builtin_functions()
+            .expect("register should succeed");
+
+        let result = engine
+            .exec_script(r#"send_rpc("ping", "{}")"#)
+            .await;
+        assert!(result.is_err(), "send_rpc on unconnected client should error");
+    }
+
+    /// Basic sanity check: a Lua script with no RPC calls should execute successfully.
+    #[tokio::test]
+    async fn test_exec_script_basic() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        engine
+            .register_builtin_functions()
+            .expect("register should succeed");
+
+        let result = engine.exec_script("x = 1 + 2").await;
+        assert!(result.is_ok(), "basic Lua script should succeed");
+    }
+
+    /// Verify that `delay(ms)` actually sleeps for approximately the requested duration.
+    #[tokio::test]
+    async fn test_exec_script_with_delay() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        engine
+            .register_builtin_functions()
+            .expect("register should succeed");
+
+        let start = std::time::Instant::now();
+        let result = engine.exec_script("delay(50)").await;
+        let elapsed = start.elapsed();
+        assert!(result.is_ok(), "delay script should succeed");
+        assert!(
+            elapsed.as_millis() >= 40,
+            "delay(50) should sleep at least ~50ms, got {}ms",
+            elapsed.as_millis()
+        );
+    }
+
+    /// Verify that the config globals (HOST, PORT, PASSWORD, CERT_PATH) that main.rs
+    /// injects into the Lua VM can be set and read back correctly.
+    #[test]
+    fn test_lua_globals_set_by_main() {
+        let client = make_test_client();
+        let engine = LuaEngine::new(client);
+        engine.lua().globals().set("HOST", "10.0.0.1").expect("set HOST");
+        engine.lua().globals().set("PORT", "80").expect("set PORT");
+        engine.lua().globals().set("PASSWORD", "secret").expect("set PASSWORD");
+        engine.lua().globals().set("CERT_PATH", "cert.pem").expect("set CERT_PATH");
+
+        let host: String = engine.lua().globals().get("HOST").unwrap();
+        assert_eq!(host, "10.0.0.1");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,9 +25,11 @@ struct CliConfig {
     #[arg(short = 'P', long)]
     password: Option<String>,
 
-    /// Enable verbose logging (include logs from webrtc_sctp).
-    #[arg(short = 'v', long)]
-    verbose: bool,
+    /// Increase log verbosity. Default output is warnings and errors only.
+    /// Use -v for debug logging (WebRTC internals silenced), or -vv for
+    /// full debug output including WebRTC internals.
+    #[arg(short = 'v', long, action = clap::ArgAction::Count)]
+    verbose: u8,
 
     // When the "lua" feature is enabled, the first positional argument is the Lua script path.
     #[cfg(feature = "lua")]
@@ -121,20 +123,7 @@ async fn main() -> AnyResult<()> {
         }
     }
 
-    // Build a filter string: by default, disable webrtc_sctp logging,
-    // but if verbose is enabled, include all logs.
-    let filter_directive = if cli_config.verbose {
-        "debug"
-    } else {
-        "debug,\
-         webrtc_sctp=off,\
-         webrtc::peer_connection=off,\
-         webrtc_dtls=off,\
-         webrtc_mdns=off,\
-         hyper_util::client=off,\
-         webrtc_data::data_channel=off,\
-         webrtc_ice=off"
-    };
+    let filter_directive = log_filter_for_verbosity(cli_config.verbose);
 
     // Initialize tracing subscriber with the constructed filter.
     // Create an EnvFilter using the directive.
@@ -236,4 +225,64 @@ info!("Executing Lua script from {}", &cli_config.lua_script);
     }
 
     Ok(())
+}
+
+/// Returns the tracing filter directive string for the given verbosity level.
+///
+/// Verbosity levels:
+///   0 (default) — `warn` with webrtc_ice silenced (quiet output)
+///   1 (-v)      — `debug` with noisy WebRTC modules silenced
+///   2+ (-vv)    — `debug` for all modules including WebRTC internals
+fn log_filter_for_verbosity(verbose: u8) -> &'static str {
+    match verbose {
+        0 => "warn,webrtc_ice=off",
+        1 => "debug,\
+              webrtc_sctp=off,\
+              webrtc::peer_connection=off,\
+              webrtc_dtls=off,\
+              webrtc_mdns=off,\
+              hyper_util::client=off,\
+              webrtc_data::data_channel=off,\
+              webrtc_ice=off",
+        _ => "debug",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Default verbosity (no -v flag) should produce warn-level output
+    /// with webrtc_ice silenced for clean user-facing output.
+    #[test]
+    fn test_verbosity_0_is_warn() {
+        let filter = log_filter_for_verbosity(0);
+        assert!(filter.starts_with("warn"), "default should be warn level");
+        assert!(filter.contains("webrtc_ice=off"), "webrtc_ice should be silenced at default level");
+    }
+
+    /// Single -v should enable debug logging but silence noisy WebRTC modules.
+    #[test]
+    fn test_verbosity_1_is_debug_filtered() {
+        let filter = log_filter_for_verbosity(1);
+        assert!(filter.starts_with("debug"), "-v should enable debug level");
+        assert!(filter.contains("webrtc_sctp=off"), "webrtc_sctp should be silenced");
+        assert!(filter.contains("webrtc_ice=off"), "webrtc_ice should be silenced");
+        assert!(filter.contains("webrtc_dtls=off"), "webrtc_dtls should be silenced");
+        assert!(filter.contains("webrtc_mdns=off"), "webrtc_mdns should be silenced");
+    }
+
+    /// Double -vv should enable full debug output with no modules silenced.
+    #[test]
+    fn test_verbosity_2_is_full_debug() {
+        let filter = log_filter_for_verbosity(2);
+        assert_eq!(filter, "debug", "-vv should be unfiltered debug");
+    }
+
+    /// Higher verbosity levels (e.g., -vvv) should behave the same as -vv.
+    #[test]
+    fn test_verbosity_3_plus_is_full_debug() {
+        assert_eq!(log_filter_for_verbosity(3), "debug");
+        assert_eq!(log_filter_for_verbosity(255), "debug");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,18 +41,42 @@ struct CliConfig {
     /// Initialize or edit the jetkvm_control.toml interactively.
     #[arg(short = 'c', long = "config_init")]
     config_init: bool,
-    
+
+    /// Path to a specific jetkvm_control.toml config file.
+    /// When provided, this takes precedence over the default search locations
+    /// (current directory, CARGO_MANIFEST_DIR, /etc/jetkvm_control/).
+    #[arg(short = 'f', long = "config")]
+    config_path: Option<String>,
 }
 
 /// Loads configuration from file (or uses the default) and then applies CLI overrides.
+///
+/// If `--config <path>` was provided, loads exclusively from that path (errors are fatal).
+/// Otherwise, falls back to the default search order: current directory, CARGO_MANIFEST_DIR,
+/// then system-wide (/etc/jetkvm_control/). CLI flags (-H, -P, etc.) override any file values.
 fn load_and_override_config(cli_config: &CliConfig) -> JetKvmConfig {
-    let mut config = JetKvmConfig::load().unwrap_or_else(|err| {
-        warn!(
-            "Failed to load jetkvm_control.toml ({}). Using default configuration.",
-            err
-        );
-        (JetKvmConfig::default(),"".to_string(),true)
-    });
+    let mut config = if let Some(path) = &cli_config.config_path {
+        // Explicit --config path: load from that file or fail with a clear error.
+        match JetKvmConfig::load_from_file(path) {
+            Ok(cfg) => {
+                println!("✅ Loaded config from: {}", path);
+                (cfg, path.clone(), true)
+            }
+            Err(err) => {
+                eprintln!("Error: Failed to load config from '{}': {}", path, err);
+                std::process::exit(1);
+            }
+        }
+    } else {
+        // No explicit path: search default locations.
+        JetKvmConfig::load().unwrap_or_else(|err| {
+            warn!(
+                "Failed to load jetkvm_control.toml ({}). Using default configuration.",
+                err
+            );
+            (JetKvmConfig::default(), "".to_string(), true)
+        })
+    };
 
     if let Some(host) = &cli_config.host {
         config.0.host = host.clone();


### PR DESCRIPTION
## Summary

- **Generic `send_rpc(method, params_json)` Lua binding** — enables Lua scripts to call any JSON-RPC method on the JetKVM device, including ATX power control (`setATXPowerAction`, `getATXState`) without needing dedicated Rust bindings
- **Fix WebRTC ICE gathering** — wait for ICE candidate gathering to complete before sending the SDP offer; the original code sent the offer with zero candidates, causing indefinite "no candidate pairs" connection hangs
- **`-f`/`--config <path>` CLI flag** — load `jetkvm_control.toml` from an explicit path, taking precedence over the default search locations (cwd, CARGO_MANIFEST_DIR, /etc/jetkvm_control/)
- **Default to `warn`-level logging** — quiet output by default; `-v` enables debug logging (WebRTC noise silenced), `-vv` enables full unfiltered debug
- **4 ATX power control Lua example scripts** — `atx_reset.lua`, `atx_power_short.lua`, `atx_power_long.lua`, `atx_status.lua`
- **Vendored OpenSSL** — allows building without system `libssl-dev`
- **21 unit tests** — 9 for `LuaEngine`/`send_rpc`, 8 for `JetKvmConfig` file I/O, 4 for verbosity filter logic

## Test plan

- [x] `cargo test --lib` — 17 tests pass (lua_engine + jetkvm_config)
- [x] `cargo test --bin jetkvm_control` — 4 tests pass (verbosity filter)
- [x] Verified `send_rpc` against live JetKVM device with ATX extension module
- [x] Verified `-f /path/to/config.toml` loads config from explicit path
- [x] Verified default output is clean (warn only), `-v` shows debug, `-vv` shows full debug
- [x] Verified ICE gathering fix resolves WebRTC connection stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)